### PR TITLE
Example of a more compact TOC + endnotes more pretty

### DIFF
--- a/data/dblatex-endnotes.xsl
+++ b/data/dblatex-endnotes.xsl
@@ -12,16 +12,16 @@ in front of it.
     <xsl:text>
 \usepackage{endnotes}
 \let\footnote=\endnote
-\def\enoteheading{\mbox{}\par\vskip-\baselineskip }
+\def\enoteheading{\mbox{}\par\vskip-0.2\baselineskip }
+
+% More pretty looking note
+\def\enoteformat{\rightskip=0pt \leftskip=21pt \parindent=-13pt
+\leavevmode\llap{\makeenmark}\hspace*{11pt}}
 
 % Trick to avoid many words sticking out of the right margin of the text.
 % Need to add it here with the end notes, as only one
 % latex.begindocument can be active.
 \sloppy
-
-% Hack to get correct chapter numbering with dblatex, as chapter
-% labels are ignored.
-\setcounter{chapter}{-1}
 
 \begin{document}
     </xsl:text>

--- a/myclass.cls
+++ b/myclass.cls
@@ -78,7 +78,7 @@
 % Make TOC entries without label
 \titlecontents{chapter} %
 [1.5em] % 
-{\addvspace{1em plus 0pt}\bfseries} %
+{\addvspace{0.3em plus 0pt}\bfseries} %
 {\hspace{-1.3em}} % no number, remove room reserved for it 
 {\hspace{-1.3em}} %
 {\hfill \contentspage} % dots and page number
@@ -91,7 +91,6 @@
 {0.75em} % space between dots
 [\addvspace{0pt}]
 
-
 %% Redefines the headings to remove the chapter label
 \titleformat{\chapter}[block]
 {\filcenter\huge}{\filcenter}{20pt}{\Huge}
@@ -101,6 +100,22 @@
 
 \titleformat{\subsection}
 {\filcenter\large\bfseries}{\thesubsection}{1em}{}
+
+%% New header, behaving like a chapter but formatted differently
+\titleclass{\lotheader}{top}[\part]
+\newcounter{lotheader}
+\renewcommand{\thelotheader}{\Alph{lotheader}}
+
+\titleformat{\lotheader}[block]
+{\filcenter\huge}{\filcenter}{20pt}{\Huge}
+\titlespacing*{\lotheader}{0pt}{-30pt}{40pt}
+
+% Use the new header in TOC
+\let\stdtoc=\tableofcontents
+\let\stdchapter=\chapter
+\def\tableofcontents{\let\chapter\lotheader \stdtoc{} \let\chapter\stdchapter}
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % From


### PR DESCRIPTION
With this example the TOC is on 2 pages only. Another option for endnotes is to use another package with smarter parameters like grouping endnotes by section like in the original book (not tested).