### PR TITLE
added script to convert translated &mdash;+space with " &ndash; "

### DIFF
--- a/scripts/translated_emdash_converter.rb
+++ b/scripts/translated_emdash_converter.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+REPLACE_WITH = " &ndash "
+
+is_translation = false
+
+lines = ARGF.readlines
+lines.each_with_index do |line, i|
+  case line
+  when /^msgid/ then is_translation = false
+  when /^msgstr/ then is_translation = true
+  end
+
+  unless is_translation
+    next
+  end
+
+  if line =~ /^"&mdash;/
+    lines[i-1].sub!(/ *"$/, "\"")
+  end
+  if line =~ /&mdash;"$/
+    lines[i+1].sub!(/^" */, "\"")
+  end
+
+  line.gsub!(/ *&mdash; */, REPLACE_WITH)
+end
+puts lines


### PR DESCRIPTION
I have created a ruby script to convert all translated instances of &mdash; and its surrounding spaces with " &ndash; " (or whatever specified by REPLACE_WITH). This scripts handles the cases where the &mdash; and its surrounding spaces happens to be split across multiple strings.

To run it:
`scripts/translated_emdash_converter.rb < freeculture.nb.po > freeculture.nb.po.endash`