### PR TITLE
Handle unicode thinspace (0x202F) used for (french) numbers.

### DIFF
--- a/data/dblatex-postprocess
+++ b/data/dblatex-postprocess
@@ -25,6 +25,7 @@ sed -i \
     -e 's/opphavsrettsvernetid/opp\\-havs\\-retts\\-verne\\-tid/g' \
     -e 's/opphavsrettighetsbeskyttet/opp\\-havs\\-ret\\-tig\\-hets\\-beskyt\\-tet/g' \
     -e 's/bestemmelsen/bestem\\-mel\\-sen/g' \
+    -e 's/ /\\thinspace/g' \
     $TEXFILE
 
 exit 0


### PR DESCRIPTION
By substituting this character with the latex equivalent it works for any font used.